### PR TITLE
ci: trigger publish on changelog completion

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,4 +1,4 @@
-﻿name: "Create Changelog"
+﻿name: "Update Changelog"
 
 on:
   workflow_dispatch
@@ -23,7 +23,7 @@ jobs:
           branch: main
           majorList: breaking, major
           minorList: feat, feature
-          patchList: fix, bugfix, perf, refactor, docs, test, tests
+          patchList: fix, bugfix, perf, refactor, docs, test, tests, ci
 
       - name: Create Draft Release
         uses: ncipollo/release-action@v1.12.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,11 @@
 name: "Publish to Nuget"
 
 on:
-  workflow_dispatch 
+  workflow_run:
+    workflows:
+      - "Update Changelog"
+    types:
+      - completed
 permissions:
   packages: write
   contents: read


### PR DESCRIPTION
This changes the `publish` action to trigger on successful completion of the `changelog` action.