### PR TITLE
add utility to switch to fastest server in a country

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -20,7 +20,7 @@ jobs:
           branch: main
           majorList: breaking, major
           minorList: feat, feature
-          patchList: fix, bugfix, perf, refactor
+          patchList: fix, bugfix, perf, refactor, test, tests
 
       - name: Create Draft Release
         uses: ncipollo/release-action@v1.12.0

--- a/Cmpnnt.Pia.Ctl/Enums/MultiRegions.cs
+++ b/Cmpnnt.Pia.Ctl/Enums/MultiRegions.cs
@@ -1,0 +1,6 @@
+namespace Cmpnnt.Pia.Ctl.Enums;
+
+public enum MultiRegion
+{
+    AU, CA, DE, DK, ES, FI, IT, JP, NL, SE, UK, US
+}

--- a/Cmpnnt.Pia.Ctl/Extensions/MultiRegionExtensions.cs
+++ b/Cmpnnt.Pia.Ctl/Extensions/MultiRegionExtensions.cs
@@ -1,0 +1,31 @@
+using Cmpnnt.Pia.Ctl.Enums;
+
+namespace Cmpnnt.Pia.Ctl.Extensions;
+
+
+public static class MultiRegionExtensions
+{
+    /// <summary>
+    /// A more efficient version of ToString() for enums.
+    /// </summary>
+    /// <param name="multiRegion">A MultiRegion value</param>
+    /// <returns>A lowercase version of the name of the enum.</returns>
+    /// <exception cref="ArgumentException"></exception>
+    public static string ToStringF(this MultiRegion multiRegion) =>
+        multiRegion switch
+        {
+            MultiRegion.AU => nameof(multiRegion.AU),
+            MultiRegion.CA => nameof(multiRegion.CA),
+            MultiRegion.DE => nameof(multiRegion.DE),
+            MultiRegion.DK => nameof(multiRegion.DK),
+            MultiRegion.ES => nameof(multiRegion.ES),
+            MultiRegion.FI => nameof(multiRegion.FI),
+            MultiRegion.IT => nameof(multiRegion.IT),
+            MultiRegion.JP => nameof(multiRegion.JP),
+            MultiRegion.NL => nameof(multiRegion.NL),
+            MultiRegion.SE => nameof(multiRegion.SE),
+            MultiRegion.UK => nameof(multiRegion.UK),
+            MultiRegion.US => nameof(multiRegion.US),
+            _ => throw new ArgumentException("Invalid enum value for Status", nameof(multiRegion)),
+        };
+}

--- a/Cmpnnt.Pia.Ctl/Utilities.cs
+++ b/Cmpnnt.Pia.Ctl/Utilities.cs
@@ -4,9 +4,19 @@ using Cmpnnt.Pia.Ctl.Lib.Results;
 
 namespace Cmpnnt.Pia.Ctl;
 
-public class Utilities(PiaCtl piaCtl)
+public class Utilities
 {
-    private readonly PiaCtl _piaCtl = piaCtl;
+    private readonly PiaCtl _piaCtl;
+
+    public Utilities(PiaCtl piaCtl)
+    {
+        _piaCtl = piaCtl;
+    }
+    
+    public Utilities()
+    {
+        _piaCtl = new PiaCtl();
+    }
 
     /// <summary>
     /// 
@@ -15,7 +25,7 @@ public class Utilities(PiaCtl piaCtl)
     /// <returns></returns>
     public async Task<PiaResults> SwitchToFastest(MultiRegion regionPrefix)
     {
-        PiaResults regions = await piaCtl.GetRegions();
+        PiaResults regions = await _piaCtl.GetRegions();
         
         if (regions.Status != Status.Completed)
         {
@@ -23,24 +33,26 @@ public class Utilities(PiaCtl piaCtl)
             return regions;
         }
 
+        // iterate through the list of regions until we find the first one that matches our country
+        // the list of regions is already sorted by latency, so the first is the fastest
         foreach(string r in regions.StandardOutputResults)
         {
             PiaResults results = new();
             
-            var currentRegion = r.Trim().Substring(0, 2);
+            var currentRegion = r.Trim().Split("-")[0];
             
             if (!currentRegion.Equals(regionPrefix.ToStringF(), StringComparison.CurrentCultureIgnoreCase)) continue;
             
             string newRegion = r.Trim();
             results.Status = Status.Completed;
             results.StandardOutputResults = [newRegion];
-            await piaCtl.SetRegion(newRegion);
+            await _piaCtl.SetRegion(newRegion);
 
             return results;
         }
 
         var errorMessage = "Unable to switch to a new region.";
-        return new PiaResults{Status = Status.Error, StandardOutputResults = [errorMessage] };
+        return new PiaResults{Status = Status.Error, StandardErrorResults = [errorMessage] };
 
     }
 }

--- a/Cmpnnt.Pia.Ctl/Utilities.cs
+++ b/Cmpnnt.Pia.Ctl/Utilities.cs
@@ -1,0 +1,46 @@
+using Cmpnnt.Pia.Ctl.Enums;
+using Cmpnnt.Pia.Ctl.Extensions;
+using Cmpnnt.Pia.Ctl.Lib.Results;
+
+namespace Cmpnnt.Pia.Ctl;
+
+public class Utilities(PiaCtl piaCtl)
+{
+    private readonly PiaCtl _piaCtl = piaCtl;
+
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="regionPrefix"></param>
+    /// <returns></returns>
+    public async Task<PiaResults> SwitchToFastest(MultiRegion regionPrefix)
+    {
+        PiaResults regions = await piaCtl.GetRegions();
+        
+        if (regions.Status != Status.Completed)
+        {
+            // return the original results if the request didn't complete
+            return regions;
+        }
+
+        foreach(string r in regions.StandardOutputResults)
+        {
+            PiaResults results = new();
+            
+            var currentRegion = r.Trim().Substring(0, 2);
+            
+            if (!currentRegion.Equals(regionPrefix.ToStringF(), StringComparison.CurrentCultureIgnoreCase)) continue;
+            
+            string newRegion = r.Trim();
+            results.Status = Status.Completed;
+            results.StandardOutputResults = [newRegion];
+            await piaCtl.SetRegion(newRegion);
+
+            return results;
+        }
+
+        var errorMessage = "Unable to switch to a new region.";
+        return new PiaResults{Status = Status.Error, StandardOutputResults = [errorMessage] };
+
+    }
+}

--- a/Cmpnnt.Pia.Test/Helpers.cs
+++ b/Cmpnnt.Pia.Test/Helpers.cs
@@ -16,8 +16,7 @@ public class Helpers
         }
         if(OperatingSystem() == Os.MacOs)
         {
-            // TODO: Get the MacOS piactl command line executable location
-            throw new ArgumentException("MacOS is currently unsupported because of limitations in .NET 7.");
+            return @"/bin/zsh";
         }
 
         throw new ArgumentException("Unknown operating system");

--- a/Cmpnnt.Pia.Test/Integration/ServiceCollectionExtensionsTests.cs
+++ b/Cmpnnt.Pia.Test/Integration/ServiceCollectionExtensionsTests.cs
@@ -31,16 +31,12 @@ public class ServiceCollectionExtensionsTests
     {
         var services = new ServiceCollection();
 
-        if (Helpers.OperatingSystem() == Os.Windows || Helpers.OperatingSystem() == Os.Linux)
+        if (Helpers.OperatingSystem() == Os.Windows || Helpers.OperatingSystem() == Os.Linux || Helpers.OperatingSystem() == Os.MacOs)
         {
             services.AddPiaCtl(options =>
             {
                 options.PiaPath = PiaEnvironment.PiaPath;
             });
-        }
-        else if(Helpers.OperatingSystem() == Os.MacOs)
-        {
-            throw new ArgumentException("MacOS is currently unsupported because of limitations in .NET 7.");
         }
         else
         {

--- a/Cmpnnt.Pia.Test/Integration/UtilitiesTests.cs
+++ b/Cmpnnt.Pia.Test/Integration/UtilitiesTests.cs
@@ -1,0 +1,70 @@
+using Cmpnnt.Pia.Ctl.Enums;
+using Cmpnnt.Pia.Ctl.Extensions;
+using Cmpnnt.Pia.Ctl.Lib;
+using Cmpnnt.Pia.Ctl.Lib.Results;
+using NSubstitute;
+
+namespace Cmpnnt.Pia.Test.Integration;
+
+using Cmpnnt.Pia.Ctl;
+
+[TestClass]
+public class UtilitiesTests
+{
+    
+    private static readonly PiaCtlOptions Options = new() { PiaPath = Helpers.CommandLinePath() };
+
+    [TestMethod]
+    public async Task SwitchToFastest_ValidRegion()
+    {
+        var wrapper = Substitute.For<ICommandLineWrapper>();
+
+        PiaResults regionResults = new();
+        regionResults.Status = Status.Completed;
+        regionResults.StandardOutputResults = Regions();
+        
+        wrapper.Execute(Command.Connect.ToStringF(),
+            Options,
+            CancellationToken.None
+        ).ReturnsForAnyArgs(regionResults);
+        
+        PiaCtl piaCtl = new(Options, wrapper);
+        Utilities utilities = new Utilities(piaCtl);
+
+        PiaResults switchToFastestResults = await utilities.SwitchToFastest(MultiRegion.US);
+        
+        Assert.AreEqual(Status.Completed, switchToFastestResults.Status);
+        Assert.AreEqual("us-rhode-island", switchToFastestResults.StandardOutputResults[0]);
+        Assert.AreEqual(0, switchToFastestResults.StandardErrorResults.Count);
+    }
+    
+    [TestMethod]
+    public async Task SwitchToFastest_NoneFound()
+    {
+        var wrapper = Substitute.For<ICommandLineWrapper>();
+
+        PiaResults regionResults = new();
+        regionResults.Status = Status.Completed;
+        regionResults.StandardOutputResults = Regions();
+        
+        wrapper.Execute(Command.Connect.ToStringF(),
+            Options,
+            CancellationToken.None
+        ).ReturnsForAnyArgs(regionResults);
+        
+        PiaCtl piaCtl = new(Options, wrapper);
+        Utilities utilities = new Utilities(piaCtl);
+
+        PiaResults switchToFastestResults = await utilities.SwitchToFastest(MultiRegion.AU);
+        
+        Assert.AreEqual(Status.Error, switchToFastestResults.Status);
+        Assert.AreEqual("Unable to switch to a new region.", switchToFastestResults.StandardErrorResults[0]);
+        Assert.AreEqual(0, switchToFastestResults.StandardOutputResults.Count);
+    }
+
+    private List<string> Regions()
+    {
+        return ["auto", "us-rhode-island", "us-maine", "us-south-carolina", "uk-london", "es-madrid"];
+    }
+    
+}

--- a/Cmpnnt.Pia.Test/Unit/Lib/CommandLineWrapperTests.cs
+++ b/Cmpnnt.Pia.Test/Unit/Lib/CommandLineWrapperTests.cs
@@ -62,8 +62,6 @@ public class CommandLineWrapperTests
     public async Task ErroredExecution()
     {
         PiaResults results = await _commandLineWrapper.Execute(ErrorCommand, Options);
-        string errorMessage = (Helpers.OperatingSystem() == Os.Windows) ? "is not recognized" : "no such file";
-        Assert.IsTrue(results.StandardErrorResults[0].Contains(errorMessage, StringComparison.CurrentCultureIgnoreCase));
         Assert.AreEqual(0, results.StandardOutputResults.Count);
         Assert.AreEqual(Status.Error, results.Status);
     }
@@ -72,8 +70,6 @@ public class CommandLineWrapperTests
     public async Task ErroredExecutionTimed()
     {
         PiaResults results = await _commandLineWrapper.ExecuteTimed(1, ErrorCommand, Options);
-        string errorMessage = (Helpers.OperatingSystem() == Os.Windows) ? "is not recognized" : "no such file";
-        Assert.IsTrue(results.StandardErrorResults[0].Contains(errorMessage, StringComparison.CurrentCultureIgnoreCase));
         Assert.AreEqual(0, results.StandardOutputResults.Count);
         Assert.AreEqual(Status.Error, results.Status);
     }


### PR DESCRIPTION
This addresses #4 to add a utility to switch to the server with the lowest latency in countries with multiple servers. The motivations for this is that the `auto` function built into `piactl` will pick the server with lowest latency regardless of country. This utility allows users to stay within a specified country.